### PR TITLE
Cleaned up registration code

### DIFF
--- a/backend/src/image_processing/cpp/PixelRegestor.cpp
+++ b/backend/src/image_processing/cpp/PixelRegestor.cpp
@@ -101,7 +101,7 @@ void PixelRegestor::execute(CommunicationObj* comms, btrgb::ArtObject* images) {
     imMatches.convertTo(matchfloat, CV_32FC3, 1.0 / 0xFF);
     btrgb::Image* btrgb_matches(new btrgb::Image("matches"));
     btrgb_matches->initImage(matchfloat);
-    comms->send_base64(btrgb_matches, btrgb::PNG, btrgb::FULL);
+    comms->send_base64(btrgb_matches, btrgb::FULL);
     images->setImage("matches", btrgb_matches);
     images->outputImageAs(btrgb::PNG, "matches");
     images->deleteImage("matches");
@@ -123,7 +123,6 @@ void PixelRegestor::execute(CommunicationObj* comms, btrgb::ArtObject* images) {
     cout << "Estimated homography : \n" << h;
     comms->send_progress(1, "PixelRegestor - Done");
 
-    cv::waitKey();
 
     //Outputs TIFFs for each image group for after this step, temporary
     images->outputImageAs(btrgb::TIFF, "art1", "art1_rgstr");


### PR DESCRIPTION
Working registration based on the main branch.

Run time is roughly 30 seconds for Cannon and 1 minute for Sony images. Can lower features to improve time at cost of accuracy.