### PR TITLE
Fixed bit depth problem

### DIFF
--- a/backend/src/ImageUtil/Image.hpp
+++ b/backend/src/ImageUtil/Image.hpp
@@ -100,7 +100,7 @@ namespace btrgb {
             ColorSpace getColorProfile();
 
             void recycle();
-            int _raw_bit_depth = 0;
+            std::shared_ptr<int> _raw_bit_depth;
             
             /* ====== static ======= */
             static bool is_tiff(std::string filename);

--- a/backend/src/image_processing/cpp/BitDepthScaler.cpp
+++ b/backend/src/image_processing/cpp/BitDepthScaler.cpp
@@ -13,15 +13,16 @@ void BitDepthScaler::execute(CommunicationObj* comms, btrgb::ArtObject* images) 
     double count = 0;
     comms->send_progress(0, "BitDepthScaler");
     for(const auto& [key, im] : *images) {
+        int raw_bd = *(im->_raw_bit_depth);
 
         /* Output message. */
         std::stringstream out3;
-        out3 << "Scaling \"" << im->getName() << "\" from " << im->_raw_bit_depth << " to 16 bits...";
+        out3 << "Scaling \"" << im->getName() << "\" from " << raw_bd << " to 16 bits...";
         comms->send_info(out3.str(), "BitDepthScaler");
 
 
         /* If the bit depth is invalid or already 16 bits: skip, do not scale anything. */
-        if (im->_raw_bit_depth < 16 && im->_raw_bit_depth >= 8) {
+        if (raw_bd < 16 && raw_bd >= 8) {
 
             /* Math:
             * scaler = (2^16 - 1) / (2^bit_depth - 1)
@@ -29,7 +30,7 @@ void BitDepthScaler::execute(CommunicationObj* comms, btrgb::ArtObject* images) 
             * The value of two to any power can be performed with bit shifting:
             * 2^x = 1 << x
             */
-            float scaler = float( (1 << 16) - 1 ) / float( (1 << im->_raw_bit_depth) - 1);
+            float scaler = float( (1 << 16) - 1 ) / float( (1 << raw_bd) - 1);
 
             /* Multiply each element in matrix by the scaler. */
             im->getMat() *= scaler;

--- a/backend/src/image_processing/cpp/ImageReader.cpp
+++ b/backend/src/image_processing/cpp/ImageReader.cpp
@@ -45,7 +45,7 @@ void ImageReader::execute(CommunicationObj* comms, btrgb::ArtObject* images) {
     comms->send_info("Reading In Raw Image Data!", "ImageReader");
 
     btrgb::BitDepthFinder util;
-    int bit_depth = -1;
+    std::shared_ptr<int> bit_depth(new int(-1));
 
     double total = images->imageCount();
     double count = 0;
@@ -73,13 +73,13 @@ void ImageReader::execute(CommunicationObj* comms, btrgb::ArtObject* images) {
 
             /* Find bit depth if image is white field #1. */
             if(key == "white1") {
-                bit_depth = util.get_bit_depth(
+                *bit_depth = util.get_bit_depth(
                     (uint16_t*) raw_im.data,    
                     raw_im.cols, 
                     raw_im.rows,
                     raw_im.channels()
                 );
-                if(bit_depth < 0)
+                if(*bit_depth < 0)
                     throw std::runtime_error(" Bit depth detection of 'white1' failed." );
             }
 
@@ -89,10 +89,10 @@ void ImageReader::execute(CommunicationObj* comms, btrgb::ArtObject* images) {
 
             /* Init btrgb::Image object. */
             im->initImage(float_im);
+            im->_raw_bit_depth = bit_depth;
             
             count++;
             comms->send_progress(count/total, "ImageReader");
-
         }
         catch(const btrgb::LibRawFileTypeUnsupported& e) {
             comms->send_error("File type unknown, or unsupported by LibRaw.", "ImageReader");


### PR DESCRIPTION
It simple wasn't saving the bit depth. Previously the bit depths would get updated in an additional for loop at the end but that must have been deleted. It now uses a shared pointer so that the previously process raws will get the bit depth detected from white1 without needing to loop through all of them again.