### PR TITLE
Backend refactor arg handling

### DIFF
--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -40,3 +40,23 @@ INIT_M = [0.10, 0.10, 0.25, 0.50, 0.10, 0.10,
           0.10, 0.10, 0.25, 0.10, 0.10, 0.50]
 INIT_O = [0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
 INIT_MOARR = INIT_M + INIT_O
+
+# Usage help messages
+TARGET_TYPE_HELP = 'The color target reference data; defaults to NGT'
+TOP_LEFT_X_HELP = 'Pixel value of the top-left of the upright color target from the left end of the color-target image'
+BOTTOM_RIGHT_X_HELP = 'Pixel value of the bottom-right of the upright color target from the left end of the color-target image'
+TOP_LEFT_Y_HELP = 'Pixel value of the top-left of the upright color target from the top end of the color-target image'
+BOTTOM_RIGHT_Y_HELP = 'Pixel value of the bottom-right of the upright color target from the top end of the color-target image'
+WHITE_COL_HELP = 'Column of selected white patch from left of target'
+WHITE_ROW_HELP = 'Row of selected white patch from top of target'
+IMAGES_HELP = '''Images should be added in this order:
+        Target A
+        Target B
+        Flat Field A
+        Flat Field B
+        Dark Field A
+        Dark Field B
+        Subject A (Optional)
+        Subject B (OptionaL)
+        Additional Images... (A and B)
+    '''

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -18,37 +18,72 @@ import sys
 from pipelines import processing_pipeline
 from packet import Packet
 from target import Target
+import argparse
 
 
 def main():
     """ App entry point """
-    # Error checking
-    if len(sys.argv) < 10:
-        print(len(sys.argv))
-        print("Missing File Paths")
-        exit()
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
 
-    # TODO: stadardize parsing of arguments
+    """
+    Whether the target is combined with the image to be processed
+    """
+    parser.add_argument('--combined-target-subject', action='store_true', help='Include this flag if the first image contains the color target')
+
+    """
+    Top left & bottom right of (NGT at the moment) target (pixels)
+    """
+    parser.add_argument('top_left_x', help='Pixel value of the top-left of the color target from the left end of the color-target image')
+    parser.add_argument('bottom_right_x', help='Pixel value of the bottom-right of the color target from the left end of the color-target image')
+    parser.add_argument('top_left_y', help='Pixel value of the top-left of the color target from the top end of the color-target image')
+    parser.add_argument('bottom_right_y', help='Pixel value of the bottom-right of the color target from the top end of the color-target image')
+
+    """
+    Location of white square on target image
+    """
+    parser.add_argument('white_col', help='Column of selected white patch from left of target')
+    parser.add_argument('white_row', help='Row of selected white patch from top of target')
+
+    images_help = '''
+    Images should be added in this order:
+        Target A (Required unless --combined-target-subject is True)
+        Target B (Required unless --combined-target-subject is True)
+        Flat Field A
+        Flat Field B
+        Dark Field A
+        Dark Field B
+        Subject A
+        Subject B
+        Additional Images... (A and B)
+    '''
+    parser.add_argument('images', nargs='+', help=images_help)
+    args = parser.parse_args()
+
+    if len(args.images) < 6 or (len(args.images) < 8 and not args.combined_target_subject):
+        parser.print_help()
+        sys.exit(1)
 
     """ Setup packet """
     packet = Packet()
 
     # Gather target coords and white square
-    tl = (int(sys.argv[1]), int(sys.argv[3]))
-    br = (int(sys.argv[2]), int(sys.argv[4]))
-    col = int(sys.argv[5])
-    row = int(sys.argv[6])
-    target = Target(tl, br, row, col)
+    top_left = (int(args.top_left_x),
+                int(args.top_left_y))
+
+    bottom_right = (int(args.bottom_right_x),
+                    int(args.bottom_right_y))
+
+    target = Target(top_left, bottom_right, int(args.white_row), int(args.white_col))
     packet.target = target
 
     # Gather file locations
-    for i in range(7, len(sys.argv)):
-        packet.files.append(sys.argv[i])
+    # TODO: Don't duplicate subject images
+    if args.combined_target_subject:
+        packet.files.extend(args.images[4:6])
+    packet.files.extend(args.images)
 
     """ Begin pipeline """
     processing_pipeline(packet)
-
-    # TODO error handling
 
 
 if __name__ == "__main__":

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -6,6 +6,7 @@ Functions:
 
 Authors:
     Brendan Grau <https://github.com/Victoriam7>
+    Keenan Miller <https://github.com/keenanm500>
 
 License:
     © 2022 BeyondRGB
@@ -13,71 +14,57 @@ License:
 """
 # Python imports
 import sys
+import argparse
 
 # Local imports
 from pipelines import processing_pipeline
 from packet import Packet
 from target import Target
-import argparse
+from parser import Parser
+import constants
 
 
 def main():
-    """ App entry point """
-    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    # App entry point
+    parser = Parser(formatter_class=argparse.RawTextHelpFormatter)
 
-    parser.add_argument('-t', '--target', choices=['NGT', 'APT', 'CCSG', 'CC'], default='NGT', help='The color target reference data')
+    parser.add_argument('-t', '--target', choices=['NGT', 'APT', 'CCSG', 'CC'], default='NGT', help=constants.TARGET_TYPE_HELP)
 
-    """
-    Top left & bottom right of (NGT at the moment) target (pixels)
-    """
-    parser.add_argument('top_left_x', help='Pixel value of the top-left of the color target from the left end of the color-target image')
-    parser.add_argument('bottom_right_x', help='Pixel value of the bottom-right of the color target from the left end of the color-target image')
-    parser.add_argument('top_left_y', help='Pixel value of the top-left of the color target from the top end of the color-target image')
-    parser.add_argument('bottom_right_y', help='Pixel value of the bottom-right of the color target from the top end of the color-target image')
+    # Top left & bottom right of (NGT at the moment) target (pixels)
+    parser.add_argument('top_left_x', help=constants.TOP_LEFT_X_HELP)
+    parser.add_argument('bottom_right_x', help=constants.BOTTOM_RIGHT_X_HELP)
+    parser.add_argument('top_left_y', help=constants.TOP_LEFT_Y_HELP)
+    parser.add_argument('bottom_right_y', help=constants.BOTTOM_RIGHT_Y_HELP)
 
-    """
-    Location of white square on target image
-    """
-    parser.add_argument('white_col', help='Column of selected white patch from left of target')
-    parser.add_argument('white_row', help='Row of selected white patch from top of target')
+    # Location of white square on target image
+    parser.add_argument('white_col', help=constants.WHITE_COL_HELP)
+    parser.add_argument('white_row', help=constants.WHITE_ROW_HELP)
 
-    images_help = '''
-    Images should be added in this order:
-        Target A
-        Target B
-        Flat Field A
-        Flat Field B
-        Dark Field A
-        Dark Field B
-        Subject A (Optional)
-        Subject B (OptionaL)
-        Additional Images... (A and B)
-    '''
-    parser.add_argument('images', nargs='+', help=images_help)
+    parser.add_argument('images', nargs='+', help=constants.IMAGES_HELP)
     args = parser.parse_args()
 
     if len(args.images) < 6:
         parser.print_help()
         sys.exit(1)
 
-    """ Setup packet """
-    packet = Packet()
-
     # Gather target coords and white square
-    top_left = (int(args.top_left_x),
-                int(args.top_left_y))
-
-    bottom_right = (int(args.bottom_right_x),
-                    int(args.bottom_right_y))
+    top_left = (int(args.top_left_x), int(args.top_left_y))
+    bottom_right = (int(args.bottom_right_x), int(args.bottom_right_y))
 
     target = Target(top_left, bottom_right, int(args.white_row), int(args.white_col))
-    packet.target = target
 
-    # Gather file locations
-    packet.files.extend(args.images)
+    # Setup packet
+    packet = build_packet(args.images, target)
 
-    """ Begin pipeline """
+    # Begin pipeline
     processing_pipeline(packet)
+
+
+def build_packet(images, target):
+    packet = Packet()
+    packet.files.extend(images)
+    packet.target = target
+    return packet
 
 
 if __name__ == "__main__":

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -25,10 +25,7 @@ def main():
     """ App entry point """
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
 
-    """
-    Whether the target is combined with the image to be processed
-    """
-    parser.add_argument('--combined-target-subject', action='store_true', help='Include this flag if the first image contains the color target')
+    parser.add_argument('-t', '--target', choices=['NGT', 'APT', 'CCSG', 'CC'], default='NGT', help='The color target reference data')
 
     """
     Top left & bottom right of (NGT at the moment) target (pixels)
@@ -46,20 +43,20 @@ def main():
 
     images_help = '''
     Images should be added in this order:
-        Target A (Required unless --combined-target-subject is True)
-        Target B (Required unless --combined-target-subject is True)
+        Target A
+        Target B
         Flat Field A
         Flat Field B
         Dark Field A
         Dark Field B
-        Subject A
-        Subject B
+        Subject A (Optional)
+        Subject B (OptionaL)
         Additional Images... (A and B)
     '''
     parser.add_argument('images', nargs='+', help=images_help)
     args = parser.parse_args()
 
-    if len(args.images) < 6 or (len(args.images) < 8 and not args.combined_target_subject):
+    if len(args.images) < 6:
         parser.print_help()
         sys.exit(1)
 
@@ -77,9 +74,6 @@ def main():
     packet.target = target
 
     # Gather file locations
-    # TODO: Don't duplicate subject images
-    if args.combined_target_subject:
-        packet.files.extend(args.images[4:6])
     packet.files.extend(args.images)
 
     """ Begin pipeline """

--- a/backend/src/parser.py
+++ b/backend/src/parser.py
@@ -1,0 +1,9 @@
+import sys
+import argparse
+
+
+class Parser(argparse.ArgumentParser):
+    """ Custom parser to allow for a custom error message """
+    def error(self, message):
+        self.print_help()
+        sys.exit(2)

--- a/backend/src/parser.py
+++ b/backend/src/parser.py
@@ -1,3 +1,16 @@
+""" parser.py
+
+This parser overrides argparse to allow for automatic
+printing of the help message when a user inputs invalid
+arguments.
+
+Authors:
+    Keenan Miller <https://github.com/keenanm500>
+
+License:
+    © 2022 BeyondRGB
+    This code is licensed under the MIT license (see LICENSE.txt for details)
+"""
 import sys
 import argparse
 

--- a/backend/src/pipelines.py
+++ b/backend/src/pipelines.py
@@ -36,8 +36,8 @@ def processing_pipeline(packet):
     num_files = len(packet.files)
 
     # Validate request
-    if num_files < 8 or num_files % 2 != 0:
-        raise MissingFilesException(8, num_files)
+    if num_files < 6 or num_files % 2 != 0:
+        raise MissingFilesException(6, num_files)
 
     # Generate array swap space and load files
     packet.generate_swap()


### PR DESCRIPTION
This modifies how we accept input into the backend-refactor. Args should be in the same order that they are currently inputted, with the addition of a (currently unused) color target option (NGT, etc). This also displays help info if someone doesn't input data correctly. 