### PR TITLE
Minor image auto-sort fix

### DIFF
--- a/frontend/src/renderer/util/autoSortStandards.svelte
+++ b/frontend/src/renderer/util/autoSortStandards.svelte
@@ -1,5 +1,5 @@
 <script context="module">
-    import { maxBy, each, includes, size, filter } from "lodash";
+    import { maxBy, split, each, size, filter } from "lodash";
     import { findBestMatch } from "./stringCompare";
 
     const matchingStandards = [
@@ -10,7 +10,8 @@
             "object",
             "art",
             "exhibit",
-            "paint"
+            "paint",
+            "subject"
         ], [
             // color target
             "target",
@@ -78,9 +79,8 @@
 
             for(let i = 0; i < matchingStandards.length; i++) {
                 each(matchingStandards[i], function (string) {
-                    if(includes(image.name.toLowerCase(), string.toLowerCase())) {
-                        image[probabilityScoreProperties[i]]++;
-                    }
+                    const count = split(image.name.toLowerCase(), string.toLowerCase()).length - 1;
+                    image[probabilityScoreProperties[i]] += count;
                 });
             }
         });


### PR DESCRIPTION
Image auto-sort functionality was checking whether or not specific strings exist in the image paths. if the image paths are as follows:
- Documents/art/art.ARW
- Documents/art/white.ARW

They will both get only 1 "match point" for the string "art". This change simply counts the occurrences to effectively ignore the parts of the path that are shared by the images.