### PR TITLE
update charts to indicate expected and actual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+CppProperties.json
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/backend/src/ImageUtil/ImageReader/LibRawReader.cpp
+++ b/backend/src/ImageUtil/ImageReader/LibRawReader.cpp
@@ -71,7 +71,7 @@ void LibRawReader::_configLibRawParams() {
     opt->user_qual = 0;
 
     /* Use raw speed. */
-    opt->use_rawspeed = 1;
+    //opt->use_rawspeed = 1;
 
 }
 

--- a/frontend/src/renderer/components/Charts/AtomicVectorChart.svelte
+++ b/frontend/src/renderer/components/Charts/AtomicVectorChart.svelte
@@ -6,6 +6,7 @@
     export let dataLC;
 
     const colors = [];
+    const annotations = [];
     let data = [];
 
     const getData = function () {
@@ -20,10 +21,24 @@
                 data.push(entry);
                 colors.push(item.color);
             }
+          
             entry.data.push({
                 y: item.b || item.l,
                 x: item.a || item.c,
             });
+            annotations.push({
+                y: item.b || item.l,
+                x: item.a || item.c,
+                marker:{
+                    fillColor: item.color,
+                    strokeWidth:1,
+                    size:3,
+                    strokeColor: entry.data.length %2 == 0 ? "#000" : "#FFF",
+                }
+            })
+            if("B:4" == entry.series){
+                console.log(item)
+            }
         });
         return data;
     };
@@ -31,11 +46,13 @@
     const getOptions = function() {
         return {
             series: getData(),
-            markers: {
+            markers: { 
                 size: 5,
                 colors: colors,
-                strokeColor: '#000',
-                strokeWidth: 1
+                strokeWidth: 0
+            },
+            annotations: {
+                points:annotations
             },
             chart: {
                 animations: {
@@ -76,7 +93,18 @@
                 }
             },
             legend: {
-                show: false
+                show: true,
+                labels:{
+                    colors:["#FFF", "#FFF"]
+                },
+                customLegendItems: ["Actual", "Expected"],
+                markers: { 
+                    size: 5,
+                    strokeWidth: 2, 
+                    strokeColor:"#FFF",
+                    fillColors: ["#FFF", "#000"]
+                
+                }
             },
             xaxis: {
                 labels: {


### PR DESCRIPTION
This updates the charts in calibration reports to indicate which points are actual and which are expected, and adds a legend to indicate the difference between actual and expected. 
Resolves #182 
Current graph:
![image](https://github.com/BeyondRGB/Imaging-Art-beyond-RGB/assets/15960388/a275700a-24ca-4970-baf7-eca10d0a5066)
