### PR TITLE
191 open file location bug

### DIFF
--- a/frontend/src/main/index.js
+++ b/frontend/src/main/index.js
@@ -60,6 +60,14 @@ ipcMain.handle('ipc-getPort', async (event, arg) => {
   return freePort;
 });
 
+//Use the shell to open the File explorer as a separate process,
+//as oppossed to a child process of the BeyondRGB application.
+ipcMain.handle('ipc-openFileExplorer', async (event, arg) => {
+  const result = await shell.openPath(arg.directory) // Open the given directory/file in the default manner.
+  return result ;
+});
+
+
 ipcMain.handle('ipc-Dialog', async (event, arg) => {
   let properties = ['openFile', 'multiSelections'];
   let filters = [];

--- a/frontend/src/main/index.js
+++ b/frontend/src/main/index.js
@@ -2,6 +2,7 @@ const { app, BrowserWindow, dialog, ipcMain } = require('electron');
 const path = require('path');
 const child_process = require('child_process');
 const getPortSync = require('get-port-sync');
+const { shell } = require('electron')
 
 let freePort = 47382;
 
@@ -62,6 +63,7 @@ ipcMain.handle('ipc-getPort', async (event, arg) => {
 ipcMain.handle('ipc-Dialog', async (event, arg) => {
   let properties = ['openFile', 'multiSelections'];
   let filters = [];
+  let defaultPath;
   console.log(arg);
   if (arg.type === "Dir") {
     properties = ["openDirectory"];
@@ -89,9 +91,12 @@ ipcMain.handle('ipc-Dialog', async (event, arg) => {
     });
   }
 
-  
+  if(arg.defaultPath !== undefined) {
+    defaultPath = arg.defaultPath;
+  }
 
   const dia = await dialog.showOpenDialog({
+    defaultPath,
     properties,
     filters
   }).then(result => {

--- a/frontend/src/main/index.js
+++ b/frontend/src/main/index.js
@@ -68,6 +68,8 @@ ipcMain.handle('ipc-openFileExplorer', async (event, arg) => {
 });
 
 
+//Opens a "file selector" as a child process of BeyondRGB application.
+//Intended for user to select files/directories during Processing setup
 ipcMain.handle('ipc-Dialog', async (event, arg) => {
   let properties = ['openFile', 'multiSelections'];
   let filters = [];

--- a/frontend/src/main/preload.js
+++ b/frontend/src/main/preload.js
@@ -13,5 +13,9 @@ contextBridge.exposeInMainWorld('electron', {
   async openNewWindow() {
     const result = await ipcRenderer.invoke('ipc-createNewWindow');
     return result;
+  },
+  async openFileExplorer(arg) {
+    const result = ipcRenderer.invoke('ipc-openFileExplorer', arg);
+    return result;
   }
 });

--- a/frontend/src/renderer/components/FileSelector.svelte
+++ b/frontend/src/renderer/components/FileSelector.svelte
@@ -4,6 +4,7 @@
   import Dropzone from "svelte-file-dropzone";
   export let type = "File";
   export let filter = "None";
+  export let defaultPath;
   export let label = "Select Files";
   export let filePaths = [];
   export let icon = FilePlusIcon;
@@ -11,7 +12,7 @@
   let ipcResponse;
 
   const temp = async () => {
-    ipcResponse = await window.electron.handle({ type, filter });
+    ipcResponse = await window.electron.handle({ type, filter, defaultPath });
   };
 
   $: if (ipcResponse) {

--- a/frontend/src/renderer/components/Process/Tabs/Processing.svelte
+++ b/frontend/src/renderer/components/Process/Tabs/Processing.svelte
@@ -78,8 +78,6 @@
     //cut off the .btrgb file portion to just get the directory
     defaultPath = defaultPath.replace(pattern, "\\");
     //yields something like $processState.destDir + "/BeyondRGB_2024-02-01_20-36-12\\", so replace this other forward slash
-    let type = "File";
-    let filter = "None";
     await window.electron.openFileExplorer({directory:defaultPath})
   }
 </script>
@@ -89,7 +87,7 @@
     <div class="completedBox">
       <div class="completedOptions">
         <button on:click={() => handleComplete(0)}>View Image</button>
-        <button on:click={async () => {await openFileExplorer();}}
+        <button on:click={() => {openFileExplorer()}}
           >Open File Location</button
         >
         <button on:click={() => handleComplete(1)}>Process Another Image</button

--- a/frontend/src/renderer/components/Process/Tabs/Processing.svelte
+++ b/frontend/src/renderer/components/Process/Tabs/Processing.svelte
@@ -57,6 +57,7 @@
   }
 
 
+  //Open the file explorer using ipc after an image is finished processing. 
   const openFileExplorer = async() =>{
     let defaultPath = $viewState.projectKey;
     //$viewState.projectKey is the filepath of the .btrgb file, but has some odd syntax with forward and backslashes, so it needs cleaning
@@ -68,9 +69,7 @@
     defaultPath = defaultPath.replace("/", "\\")
     let type = "File";
     let filter = "None";
-    await window.electron.handle({ type, filter, defaultPath });
-    
-
+    await window.electron.openFileExplorer({directory:defaultPath})
   }
 </script>
 

--- a/frontend/src/renderer/components/Process/Tabs/Processing.svelte
+++ b/frontend/src/renderer/components/Process/Tabs/Processing.svelte
@@ -52,10 +52,25 @@
       currentPage.set("SpecPicker");
       console.log({ RESETING: $currentPage });
     } else if (id === 1) {
-      // open in election
-    } else if (id === 2) {
       reset();
     }
+  }
+
+
+  const openFileExplorer = async() =>{
+    let defaultPath = $viewState.projectKey;
+    //$viewState.projectKey is the filepath of the .btrgb file, but has some odd syntax with forward and backslashes, so it needs cleaning
+    //match "/\BeyondRGB_" prefix, followed by 1+digits with ".btrgb" at the end. The 'i' at the end means case insensitive
+    let pattern = /\/\\BeyondRGB_\d+.btrgb$/i;
+    //cut off the .btrgb file portion to just get the directory
+    defaultPath = defaultPath.replace(pattern, "\\");
+    //yields something like $processState.destDir + "/BeyondRGB_2024-02-01_20-36-12\\", so replace this other forward slash
+    defaultPath = defaultPath.replace("/", "\\")
+    let type = "File";
+    let filter = "None";
+    await window.electron.handle({ type, filter, defaultPath });
+    
+
   }
 </script>
 
@@ -64,10 +79,10 @@
     <div class="completedBox">
       <div class="completedOptions">
         <button on:click={() => handleComplete(0)}>View Image</button>
-        <button disabled on:click={() => handleComplete(1)}
+        <button on:click={async () => {await openFileExplorer();}}
           >Open File Location</button
         >
-        <button on:click={() => handleComplete(2)}>Process Another Image</button
+        <button on:click={() => handleComplete(1)}>Process Another Image</button
         >
       </div>
     </div>

--- a/frontend/src/renderer/components/Process/Tabs/Processing.svelte
+++ b/frontend/src/renderer/components/Process/Tabs/Processing.svelte
@@ -62,11 +62,10 @@
     let defaultPath = $viewState.projectKey;
     //$viewState.projectKey is the filepath of the .btrgb file, but has some odd syntax with forward and backslashes, so it needs cleaning
     //match "/\BeyondRGB_" prefix, followed by 1+digits with ".btrgb" at the end. The 'i' at the end means case insensitive
-    let pattern = /\/\\BeyondRGB_\d+.btrgb$/i;
+    let pattern = /\\BeyondRGB_\d+.btrgb$/i;
     //cut off the .btrgb file portion to just get the directory
     defaultPath = defaultPath.replace(pattern, "\\");
     //yields something like $processState.destDir + "/BeyondRGB_2024-02-01_20-36-12\\", so replace this other forward slash
-    defaultPath = defaultPath.replace("/", "\\")
     let type = "File";
     let filter = "None";
     await window.electron.openFileExplorer({directory:defaultPath})

--- a/frontend/src/renderer/pages/Home.svelte
+++ b/frontend/src/renderer/pages/Home.svelte
@@ -19,6 +19,7 @@
   
   let showAbout = false;
   
+  //Open a new electron window of the BeyondRGB application using IPC
   const openNewWindow = () => {
     window.electron.openNewWindow();
   }


### PR DESCRIPTION
Resolves #191 
Fixed the "Open File Location" button at the end of Processing.

Will open the file manager using the electron shell module. Added in a new ipc handler, ipc-openFileExplorer. After the image is finished processing, the backend returns the filepath of the .btrgb file. I used regex to take off the file portion of the filepath and end up with just the directory it is located in.

First iteration:
Used the ipc-Dialog handler function to open the file explorer, but the file explorer is a child process of BeyondRGB, not its own process, and is intended to enable the user to select files/directories (like in the processing steps). I added in the optional 'defaultPath' parameter to open it in a specified directory. Also added this attribute to FileSelector.svelte.


Second Iteration:
Using the electron shell to start a new file explorer process allows the file explorer to persist even after BeyondRGB has been closed out. Decided to leave in modifications to FileSelector.svelte in case they are needed in future and they don't break anything (lmk if I should remove them).


