### PR TITLE
fixed report header not appearing with bottom nav

### DIFF
--- a/frontend/src/renderer/pages/Reports.svelte
+++ b/frontend/src/renderer/pages/Reports.svelte
@@ -142,7 +142,7 @@
 
 <style lang="postcss" global>
   .reports-main {
-    @apply flex flex-col w-full h-full overflow-y-scroll pt-[20vh];
+    @apply flex flex-col w-full h-full overflow-y-scroll ;
   }
   .art {
     @apply flex flex-col relative;
@@ -176,13 +176,13 @@
     @apply text-xl;
   }
   .report-header {
-    width: calc(100% - 6rem);
+    width: 100%;
     height: 20vh;
-    @apply fixed top-0 bg-gray-800 z-[9999] flex px-[1vw] pr-[5vw] py-4 rounded-b-xl -translate-y-full
+    @apply sticky top-0 bg-gray-800 z-[9999] flex px-[1vw] pr-[5vw] py-4 rounded-b-xl -translate-y-full
             transition-all delay-150 duration-300 ease-in justify-between;
   }
   .close-report {
-    @apply absolute top-0 right-0;
+    @apply absolute top-5 right-0;
   }
   .report-header.show {
     @apply translate-y-0;


### PR DESCRIPTION
Resolves #194 

Changed css styling for report-header on Reports page so that report-header will show when navigation bar is on the bottom of the screen

Before:
![image](https://github.com/BeyondRGB/Imaging-Art-beyond-RGB/assets/54516922/bd966d21-425c-4315-8142-e361b87a6aab)

After:
![image](https://github.com/BeyondRGB/Imaging-Art-beyond-RGB/assets/54516922/22acf7ce-136f-46ad-9705-b75e95ff0b89)
