### PR TITLE
Display image of target next to heatmap

### DIFF
--- a/backend/src/backend_process/ColorManagedImage.cpp
+++ b/backend/src/backend_process/ColorManagedImage.cpp
@@ -9,8 +9,26 @@ void ColorManagedImage::run() {
     
     try {
         std::string prj_filename = this->process_data_m->get_string("name");
+        bool target_requested =  this->process_data_m->get_bool("target_requested");
         std::ifstream prj_file(prj_filename);
-        std::string local_file = jsoncons::json::parse(prj_file)["OutPutFiles"]["CM"].as<std::string>();
+
+        std::string local_file = "";
+
+        if(target_requested){
+            try{
+                local_file = jsoncons::json::parse(prj_file)["OutPutFiles"]["CM_target"].as<std::string>();
+                std::cout << local_file << std::endl;
+            }catch(const std::exception& e){
+                //CM_target may be unavailable since it was added in BeyondRGB 2.0
+                //in which case end early using return
+                std::cout << e.what() << std::endl;
+                this->coms_obj_m->send_error("Color Managed Target image is unavailable", "ColorManagedImage", true);
+                return;
+            }
+        }else{
+            local_file = jsoncons::json::parse(prj_file)["OutPutFiles"]["CM"].as<std::string>();
+        }
+        std::cout << local_file << std::endl;
         std::string filename = prj_filename.substr(0, prj_filename.find_last_of("/\\") + 1) + local_file;
 
         if( ! btrgb::Image::is_tiff(filename) )

--- a/backend/src/image_processing/cpp/ResultsProcessor.cpp
+++ b/backend/src/image_processing/cpp/ResultsProcessor.cpp
@@ -78,8 +78,9 @@ void ResultsProcessor::output_btrgb_results(btrgb::ArtObject* images){
     // Create json object to store all file names this run outputs
     jsoncons::json output_files;
     output_files.insert_or_assign("CM", this->CM_f_name+".tiff");
+    output_files.insert_or_assign("CM_target", this->CM_target_f_name+".tiff");
     output_files.insert_or_assign("SP", this->SP_f_name+".tiff");
-    output_files.insert_or_assign("GineralInfo", this->GI_f_name);
+    output_files.insert_or_assign("GeneralInfo", this->GI_f_name);
     output_files.insert_or_assign("M_color", this->M_color_f_name);
     output_files.insert_or_assign("M_spectral", this->M_spectral_f_name);
     output_files.insert_or_assign("Colorimetry", this->colorimetry_f_name);

--- a/frontend/src/renderer/components/Charts/AtomicHeatMap.svelte
+++ b/frontend/src/renderer/components/Charts/AtomicHeatMap.svelte
@@ -90,8 +90,8 @@
         return {
             series: getData(),
             chart: {
-                height: '700px',
-                width: '700px',
+                height: '650px',
+                width: '650px',
                 type: 'heatmap',
                 toolbar: {
                     // Hamburger menu which has exports such as CSV etc.
@@ -109,12 +109,12 @@
                 enabled: true,
                 theme: 'dark',
                 y: {
-                    show: false,
-                    title: {
+                    title: { //todo keep????? y axis tooltip
                         // Displayed before the value on the tooltip, unnecessary
-                        formatter: () => ""
+                        formatter: (value) => ""//{return data?.length-value}
                     }
-                }
+                },
+                
             },
             yaxis: {
                 labels: {
@@ -129,8 +129,21 @@
                             // This gets hit for each individual square on the heatmap (displayed as tooltip value)
                             return value;
                         }
-                    }
+                    },
+                    style: {
+                        colors: ["#ffffff"]   
+                    },
                 },
+                
+            },
+            xaxis: {
+                labels: {
+                    style: {
+                        //for some reason colors: ["#ffffff", "#ffffff"] would only make the first two labels white??
+                        //so make an array the length of the x-axis of just "#ffffff"
+                        colors:  Array.from({length:data?.[0].length}, ()=> "#ffffff")
+                    }
+                }
             },
             plotOptions: {
                 heatmap: {

--- a/frontend/src/renderer/components/ImageViewer.svelte
+++ b/frontend/src/renderer/components/ImageViewer.svelte
@@ -4,10 +4,13 @@
   import { onDestroy, onMount } from "svelte";
   let viewer;
   let imageUrl;
+  export let srcUrl;
+  export let identifier = "unique-identifier";
+  let imageId = identifier+"-seadragon-viewer";
 
   const createViewer = () => {
     viewer = OpenSeadragon({
-      id: "image-seadragon-viewer",
+      id: imageId,
       prefixUrl: "/openseadragon/images/",
       immediateRender: true,
       preload: true,
@@ -65,7 +68,7 @@
   //     url: imageUrl,
   //   });
   // }
-  $: if ($processState.currentTab >= 6) {
+  $: if ($processState.currentTab >= 6 || $currentPage === "Reports") {
     if (viewer && !viewer.isOpen()) {
       console.log("Opening Image");
       console.log(viewer.isOpen());
@@ -84,7 +87,7 @@
     // console.log($processState.artStacks[0].colorTargetImage);
     console.log("New Image (Image Viewer)");
     let temp = new Image();
-    temp.src = $processState.outputImage?.dataURL;
+    temp.src = srcUrl;
 
     imageUrl = temp.src;
 
@@ -104,15 +107,14 @@
 </script>
 
 <main>
-  <!-- <div class="load"><Loader /></div> -->
-  <div id="image-seadragon-viewer" />
+  <div class="image-seadragon-viewer" id={imageId} />
 </main>
 
 <style lang="postcss">
   main {
     @apply w-full h-full ring-1 ring-gray-800 bg-gray-900/50 aspect-[3/2] shadow-lg;
   }
-  #image-seadragon-viewer {
+  .image-seadragon-viewer {
     @apply h-full w-full;
   }
   .load {

--- a/frontend/src/renderer/components/Process/Tabs/Processing.svelte
+++ b/frontend/src/renderer/components/Process/Tabs/Processing.svelte
@@ -88,7 +88,7 @@
     <div class="right">
       <div class="image">
         <h4>{$processState.outputImage?.name}</h4>
-        <ImageViewer />
+        <ImageViewer srcUrl={$processState.outputImage?.dataURL} identifier={$processState.outputImage?.name}/>
       </div>
     </div>
   </div>

--- a/frontend/src/renderer/pages/Process.svelte
+++ b/frontend/src/renderer/pages/Process.svelte
@@ -108,7 +108,7 @@ import BatchProcessingRoles from "@root/components/Process/Tabs/BatchProcessingR
     try {
       let temp = JSON.parse($messageStore[0]);
       if (
-        // CM Binary Handler
+        // CM Art Binary Handler
         temp["ResponseType"] === "ImageBinary" &&
         temp["RequestID"] === $processState.CMID
       ) {
@@ -126,7 +126,16 @@ import BatchProcessingRoles from "@root/components/Process/Tabs/BatchProcessingR
         binaryType = temp["ResponseData"]["type"];
         binaryName = temp["ResponseData"]["name"];
         binaryFor = "Thumbnail";
-      } else if (temp["ResponseType"] === "ImageBinary") {
+      } else if(
+        // Color Managed Target image Binary handler
+        temp["ResponseType"] === "ImageBinary" &&
+        temp["RequestID"] === $processState.CMTID
+      ) {
+        console.log("Color Managed Target Binary From Server");
+        binaryType = temp["ResponseData"]["type"];
+        binaryName = temp["ResponseData"]["name"];
+        binaryFor = "ColorManagedTarget";
+      }else if (temp["ResponseType"] === "ImageBinary") {
         // Color target and output binary handler
         console.log("Binary From Server");
         binaryType = temp["ResponseData"]["type"];
@@ -185,6 +194,12 @@ import BatchProcessingRoles from "@root/components/Process/Tabs/BatchProcessingR
       $viewState.colorManagedImage = {
         dataURL: temp.src,
         name: binaryName,
+      };
+    }else if(binaryFor === "ColorManagedTarget"){ 
+      console.log("Got target!");
+      $viewState.colorManagedTargetImage = {
+        dataURL:temp.src,
+        name:binaryName
       };
     }
     binaryType = null;

--- a/frontend/src/renderer/pages/Reports.svelte
+++ b/frontend/src/renderer/pages/Reports.svelte
@@ -4,6 +4,7 @@
     sendMessage,
     messageStore,
     currentPage,
+    processState,
   } from "@util/stores";
   import Heatmap from "@components/Charts/HeatMap.svelte";
   import LinearChart from "@root/components/Charts/LinearChart.svelte";
@@ -25,6 +26,24 @@
     sendMessage(JSON.stringify(msg));
   }
 
+  function colorManagedTargetImage() {
+    let randID = Math.floor(Math.random() * 999999);
+    $processState.CMTID = randID;
+    let msg = {
+      RequestID: randID,
+      RequestType: "ColorManagedImage",
+      RequestData: {
+        name: $viewState.projectKey,
+        target_requested: true,
+      },
+    };
+
+    console.log("Fetching Color Managed Target Image");
+    console.log(msg);
+    //loading = true;
+    sendMessage(JSON.stringify(msg));
+  }
+
   let toggle = false;
   $: if (
     $currentPage === "Reports" &&
@@ -33,6 +52,7 @@
   ) {
     // CALL FOR REPORTS
     toggle = true;
+    colorManagedTargetImage();
     getReports();
   }
   let mainfilePath;
@@ -73,6 +93,22 @@
     };
     toggle = false;
     mainfilePath = null;
+  }
+
+  let currentZoom=1;let stepSize=0.05;
+  function zoomImage(direction, id) { 
+      let newZoom = currentZoom + direction * stepSize; 
+    
+      // Limit the zoom level to the minimum and maximum values 
+      if (newZoom < 1 || newZoom > 3) { 
+          return; 
+      } 
+    
+      currentZoom = newZoom; 
+    
+      // Update the CSS transform of the image to scale it 
+      let image = document.querySelector('#'+id); 
+      image.style.transform = 'scale(' + currentZoom + ')'; 
   }
 </script>
 
@@ -119,7 +155,23 @@
               data={$viewState.reports.calibration}
               matrixName={"CM DeltaE Values"}
             />
+            <div style="display: flex; 
+            justify-content: center; 
+            align-items: center; 
+            padding-top:3rem;
+            height: 525px;
+            width:auto;
+            max-width:45vw;
+            overflow:hidden;" on:mousewheel={function (event) { 
+              // Zoom in or out based on the scroll direction 
+              let direction = event.deltaY > 0 ? -1 : 1; 
+              zoomImage(direction, "zoom-test2"); 
+          }}>
+            <img id="zoom-test2"  src={$viewState.colorManagedTargetImage.dataURL} alt="Color Managed Target Image"/>   
           </div>
+          </div>
+          <!-- <div class="report-item">
+          </div> -->
           <div class="report-item">
             <!-- AB vector chart -->
             <VectorChart data={$viewState.reports.calibration} matrix={"CM"} ab={true}></VectorChart>
@@ -203,7 +255,6 @@
   .verificationBar {
     @apply w-full h-full bg-gray-500 flex flex-col p-2 rounded-xl;
   }
-
   .new-window-button{
     align-self: baseline;margin-top: 5px;
   }

--- a/frontend/src/renderer/pages/Reports.svelte
+++ b/frontend/src/renderer/pages/Reports.svelte
@@ -10,6 +10,7 @@
   import LinearChart from "@root/components/Charts/LinearChart.svelte";
   import FileSelector from "@components/FileSelector.svelte";
   import VectorChart from "@components/Charts/VectorChart.svelte";
+  import ImageViewer from "@root/components/ImageViewer.svelte";
   let open = false;
 
   function getReports() {
@@ -161,12 +162,10 @@
               data={$viewState.reports.calibration}
               matrixName={"CM DeltaE Values"}
             />
-            <div class="target-image-container" on:mousewheel={detectZoom}>
-            <img id="cm-target-image" draggable=true src={$viewState.colorManagedTargetImage.dataURL} alt="Color Managed Target Image"/>   
+            <div class="target-image-container">
+              <ImageViewer srcUrl={$viewState.colorManagedTargetImage.dataURL} identifier="CM_target"/>
+            </div>
           </div>
-          </div>
-          <!-- <div class="report-item">
-          </div> -->
           <div class="report-item">
             <!-- AB vector chart -->
             <VectorChart data={$viewState.reports.calibration} matrix={"CM"} ab={true}></VectorChart>
@@ -253,14 +252,8 @@
   .new-window-button{
     align-self: baseline;margin-top: 5px;
   }
-  .target-image-container{
-    display: flex; 
-    justify-content: center; 
-    align-items: center; 
-    padding-top:3rem;
-    height: auto;
-    width:650px;
-    max-width:45vw;
-    overflow:hidden;
+  .target-image-container {
+    height:450px;
+    @apply w-full bg-blue-600/25 relative items-center flex justify-center;
   }
 </style>

--- a/frontend/src/renderer/pages/Reports.svelte
+++ b/frontend/src/renderer/pages/Reports.svelte
@@ -91,14 +91,20 @@
       calibration: null,
       verification: null,
     };
+    $viewState.colorManagedTargetImage = { dataURL: "", name: "Waiting..." };
     toggle = false;
     mainfilePath = null;
   }
 
+  function detectZoom(event){ 
+   // Zoom in or out based on the scroll direction 
+    let direction = event.deltaY > 0 ? -1 : 1; 
+    zoomImage(direction); 
+  }
+
   let currentZoom=1;let stepSize=0.05;
-  function zoomImage(direction, id) { 
+  function zoomImage(direction) { 
       let newZoom = currentZoom + direction * stepSize; 
-    
       // Limit the zoom level to the minimum and maximum values 
       if (newZoom < 1 || newZoom > 3) { 
           return; 
@@ -107,8 +113,8 @@
       currentZoom = newZoom; 
     
       // Update the CSS transform of the image to scale it 
-      let image = document.querySelector('#'+id); 
-      image.style.transform = 'scale(' + currentZoom + ')'; 
+      let image = document.querySelector("#cm-target-image"); 
+      image.style.transform = "scale(" + currentZoom + ')'; 
   }
 </script>
 
@@ -155,19 +161,8 @@
               data={$viewState.reports.calibration}
               matrixName={"CM DeltaE Values"}
             />
-            <div style="display: flex; 
-            justify-content: center; 
-            align-items: center; 
-            padding-top:3rem;
-            height: 525px;
-            width:auto;
-            max-width:45vw;
-            overflow:hidden;" on:mousewheel={function (event) { 
-              // Zoom in or out based on the scroll direction 
-              let direction = event.deltaY > 0 ? -1 : 1; 
-              zoomImage(direction, "zoom-test2"); 
-          }}>
-            <img id="zoom-test2"  src={$viewState.colorManagedTargetImage.dataURL} alt="Color Managed Target Image"/>   
+            <div class="target-image-container" on:mousewheel={detectZoom}>
+            <img id="cm-target-image" draggable=true src={$viewState.colorManagedTargetImage.dataURL} alt="Color Managed Target Image"/>   
           </div>
           </div>
           <!-- <div class="report-item">
@@ -257,5 +252,15 @@
   }
   .new-window-button{
     align-self: baseline;margin-top: 5px;
+  }
+  .target-image-container{
+    display: flex; 
+    justify-content: center; 
+    align-items: center; 
+    padding-top:3rem;
+    height: auto;
+    width:650px;
+    max-width:45vw;
+    overflow:hidden;
   }
 </style>

--- a/frontend/src/renderer/pages/SpectralPicker.svelte
+++ b/frontend/src/renderer/pages/SpectralPicker.svelte
@@ -77,6 +77,7 @@
       RequestType: "ColorManagedImage",
       RequestData: {
         name: $viewState.projectKey,
+        target_requested: false,
       },
     };
 

--- a/frontend/src/renderer/util/stores.ts
+++ b/frontend/src/renderer/util/stores.ts
@@ -14,6 +14,7 @@ export const viewState = writable({
   projectKey: null,
 
   colorManagedImage: { dataURL: "", name: "Waiting..." },
+  colorManagedTargetImage: { dataURL: "", name: "Waiting..." },
   reports: {
     calibration: null,
     verification: null
@@ -38,7 +39,7 @@ export const processState = writable({
   imageFilePaths: [],
   thumbnailID: null as number,
   colorTargetID: null,
-  CMID: null,
+  CMID: null, CMTID:null,
   whitePatchFilled: false,
   imageThumbnails: {},
   outputImage: { dataURL: "", name: "Waiting..." },
@@ -92,7 +93,7 @@ export function resetProcess() {
     thumbnailID: null,
     colorTargetID: null,
     whitePatchFilled: false,
-    CMID: null,
+    CMID: null, CMTID:null,
     imageThumbnails: {},
     outputImage: { dataURL: "", name: "Waiting..." },
     returnedFromProcessing: false,


### PR DESCRIPTION
Added the color managed target image to be displayed in the report page. Put the image binary into an ordinary <img> tag and used javascript to handle zoom. Adjusted the "ColorManagedImage" request in both backend and frontend. Added "CM_target" filename to the OutputFiles in the .btrgb file. 

I followed the same coding practice that the SpectralPicker uses to grab the color managed art image (which is admittedly weird). I did consider refactoring but was not sure if I should just refactor how one backend request is made, or how every backend requests is, which would be bigger time sink. 

View:
![image](https://github.com/BeyondRGB/Imaging-Art-beyond-RGB/assets/54516922/5fbcc901-df4c-48fb-9f8c-f3d6d7d9f7cf)

