### PR TITLE
202 sorted images display on ImageImporter tab

### DIFF
--- a/frontend/cypress/e2e/Process/test.cy.ts
+++ b/frontend/cypress/e2e/Process/test.cy.ts
@@ -1,0 +1,23 @@
+describe('Select Processing Type and Import Images Tab', () => {
+    beforeEach(() => {
+      cy.visit('http://localhost:3000/');
+      cy.get(".homeContent .homeBtn").contains("Process").click();
+    })
+
+    it('Batch Processing button works', () => {
+      cy.get("#selectProcessingTypes .homeBtn").contains("Batch Processing").click();
+      
+      cy.get("right").get(".custom-dropzone").contains("Drag and Drop Files Here");
+      cy.get("left").contains("Import Images");
+
+
+    })
+    it('Single Image Processing button works', () => {
+      cy.get("#selectProcessingTypes .homeBtn").contains("Single Image Processing").click();
+
+      cy.get("right").get(".custom-dropzone").contains("Drag and Drop Files Here");
+      cy.get("left").contains("Import Images");
+      
+
+    })    
+  })

--- a/frontend/cypress/e2e/side_menu.cy.ts
+++ b/frontend/cypress/e2e/side_menu.cy.ts
@@ -4,14 +4,14 @@ describe('Side Menu', () => {
     })
 
     it('Settings button works', () => {
-      cy.get(".homeBtn").contains("Process").click();
+      cy.get(".homeContent .homeBtn").contains("Process").click();
       cy.get(".ctlBtns .feather-settings").click();
       cy.get(".settings").should("contain", "Settings");
       cy.get(".closeDia").click();
       cy.get(".modal").should("not.exist");
     })
     it('Home button works', () => {
-      cy.get(".homeBtn").contains("Process").click();
+      cy.get(".homeContent .homeBtn").contains("Process").click();
       cy.get(".ctlBtns .feather-home").click();
       cy.get(".homeBtn").contains("Process").should("be.visible");
     })

--- a/frontend/src/renderer/components/ImageImporter.svelte
+++ b/frontend/src/renderer/components/ImageImporter.svelte
@@ -3,6 +3,7 @@
     import { processState, sendMessage} from "@util/stores";
     import { forEach, find } from "lodash";
     import { testStyle } from "@util/styles";
+    import { countFields } from "@root/util/storesUtil";
     import ImageBubble from "@components/Process/ImageBubble.svelte";
     import Dropzone from "svelte-file-dropzone";
     export let label = "Select Files";
@@ -58,10 +59,11 @@
            filePaths.push(f.name);
         });
         getThumbnails();
-        if($processState.imageFilePaths.length >= 6 && $processState.imageFilePaths.length <=8  ){
+        let totalImageCount = $processState.imageFilePaths.length + countFields($processState.artStacks[0].fields); 
+        if(totalImageCount >= 6 && totalImageCount <=8  ){
             $processState.artImageCount = 1;
-        }else if ( $processState.imageFilePaths.length > 8){
-            $processState.artImageCount = Math.ceil($processState.imageFilePaths.length - 6) / 2;
+        }else if ( totalImageCount > 8){
+            $processState.artImageCount = Math.ceil((totalImageCount - 6) / 2);
         }
     }
 

--- a/frontend/src/renderer/components/Process/Dropbox.svelte
+++ b/frontend/src/renderer/components/Process/Dropbox.svelte
@@ -10,6 +10,7 @@
     export let type;
     export let singleItem = true;
     export let showError = false;
+    export let dragDisabled = false;
 
     function handleSort(e) {
         items = e.detail.items;
@@ -18,7 +19,7 @@
 </script>
 <main>
     <div class="sectionStyle {showError && singleItem && isEmpty(items) ? 'errorStyle' : ''}">
-        <section use:dndzone={{items, flipDurationMs, type, dropFromOthersDisabled: singleItem && items.length > 0}}
+        <section use:dndzone={{items, flipDurationMs, type, dragDisabled, dropFromOthersDisabled: singleItem && items.length > 0}}
             on:consider={handleSort}
             on:finalize={handleSort}
         >

--- a/frontend/src/renderer/components/Process/Tabs/BatchProcessingRoles.svelte
+++ b/frontend/src/renderer/components/Process/Tabs/BatchProcessingRoles.svelte
@@ -211,7 +211,7 @@
         font-size: 30px;
     }
     .autoSortButton {
-        margin: 50px 65px 0 0;
+        margin: 50px 65px 2px 0;
     }
     .errorText {
         text-align: center;

--- a/frontend/src/renderer/components/Process/Tabs/BatchProcessingRoles.svelte
+++ b/frontend/src/renderer/components/Process/Tabs/BatchProcessingRoles.svelte
@@ -4,6 +4,7 @@
     import Dropbox from "@components/Process/Dropbox.svelte";
     import {get, isEmpty, each, includes} from "lodash";
     import { autoSortImages } from "@util/autoSortStandards.svelte";
+    import { countFields } from "@root/util/storesUtil";
 
     let imageStack = get($processState, 'artStacks[0].fields');
     let artImageStackA = get($batchImagesA);
@@ -20,10 +21,11 @@
     }
     // get art image count after images are updated but before we render this screen.
     $:if ($processState.currentTab ===2){
-        if($processState.imageFilePaths.length >= 6 && $processState.imageFilePaths.length <=8  ){
+        let totalImageCount = $processState.imageFilePaths.length + countFields($processState.artStacks[0].fields); 
+        if(totalImageCount >= 6 && totalImageCount <=8  ){
             artImageCount = 1;
-        }else if ( $processState.imageFilePaths.length > 8){
-            artImageCount = Math.ceil(($processState.imageFilePaths.length - 6) / 2);
+        }else if ( totalImageCount > 8){
+            artImageCount = Math.ceil((totalImageCount - 6) / 2);
         }
     }
 

--- a/frontend/src/renderer/components/Process/Tabs/ImportImages.svelte
+++ b/frontend/src/renderer/components/Process/Tabs/ImportImages.svelte
@@ -3,14 +3,17 @@
   import ImageImporter from "@components/ImageImporter.svelte";
   import {get} from "lodash";
   import Dropbox from "../Dropbox.svelte";
+  import { countFields } from "@root/util/storesUtil";
   let imageStack = get($processState, 'artStacks[0].fields');
-  let artImageCount=0;
+  let sortedImageCount=0;
+  let artImageCount = 0;
 
   // this helps force a rerender once the imageStack has been updated
   $: if ($processState.currentTab === 1) {
         imageStack = get($processState, 'artStacks[0].fields');
         artImageCount = $processState.artImageCount;
         console.log(artImageCount);
+        sortedImageCount = countFields(imageStack);
   }
 
 </script>
@@ -20,7 +23,7 @@
     <h1>Import Images</h1>
     <br><br>
     <div>
-      {#if $processState?.artStacks[0].fields.darkfieldA[0]!==undefined}
+      {#if sortedImageCount>0}
       <h2>Already Sorted Images</h2>
       <div >
         <div class="inputGroup">

--- a/frontend/src/renderer/components/Process/Tabs/ImportImages.svelte
+++ b/frontend/src/renderer/components/Process/Tabs/ImportImages.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { processState, sendMessage, messageStore } from "@util/stores";
+  import { processState } from "@util/stores";
   import ImageImporter from "@components/ImageImporter.svelte";
   import {get} from "lodash";
   import Dropbox from "../Dropbox.svelte";

--- a/frontend/src/renderer/components/Process/Tabs/ImportImages.svelte
+++ b/frontend/src/renderer/components/Process/Tabs/ImportImages.svelte
@@ -1,12 +1,61 @@
 <script lang="ts">
   import { processState, sendMessage, messageStore } from "@util/stores";
   import ImageImporter from "@components/ImageImporter.svelte";
+  import {get} from "lodash";
+  import Dropbox from "../Dropbox.svelte";
+  let imageStack = get($processState, 'artStacks[0].fields');
+  let artImageCount=0;
+
+  // this helps force a rerender once the imageStack has been updated
+  $: if ($processState.currentTab === 1) {
+        imageStack = get($processState, 'artStacks[0].fields');
+        artImageCount = $processState.artImageCount;
+        console.log(artImageCount);
+  }
 
 </script>
 
 <main>
   <left>
     <h1>Import Images</h1>
+    <br><br>
+    <div>
+      {#if $processState?.artStacks[0].fields.darkfieldA[0]!==undefined}
+      <h2>Already Sorted Images</h2>
+      <div >
+        <div class="inputGroup">
+            <div class="imageLetter">A</div>
+            <div class="imageLetter">B</div>
+        </div>
+        <h3 class="text">Object</h3>
+        <div class="artImageObjects">
+          {#each Array(artImageCount) as count, index (index)}
+          <div class="inputGroup">
+              <div class="cell"><Dropbox type="image" bind:items={imageStack.imageA[index]} singleItem={true} dragDisabled={true}/></div>
+              <div class="cell"><Dropbox type="image" bind:items={imageStack.imageB[index]} singleItem={true} dragDisabled={true}/></div>
+          </div>
+          <br>
+          {/each}
+        </div>
+      </div>
+        <h3 class="text">Target</h3>
+        <div class="inputGroup">
+          <div class="cell"><Dropbox type="image" bind:items={imageStack.targetA} singleItem={true} dragDisabled={true}/></div>
+          <div class="cell"><Dropbox type="image" bind:items={imageStack.targetB} singleItem={true} dragDisabled={true}/></div>
+        </div>
+        <h3 class="text">FlatField</h3>
+        <div class="inputGroup">
+          <div class="cell"><Dropbox type="image" bind:items={imageStack.flatfieldA} singleItem={true} dragDisabled={true}/></div>
+          <div class="cell"><Dropbox type="image" bind:items={imageStack.flatfieldB} singleItem={true} dragDisabled={true}/></div>
+        </div>
+        <h3 class="text">DarkField</h3>
+
+        <div class="inputGroup">
+          <div class="cell"><Dropbox type="image" bind:items={imageStack.darkfieldA} singleItem={true} dragDisabled={true}/></div>
+          <div class="cell"><Dropbox type="image" bind:items={imageStack.darkfieldB} singleItem={true} dragDisabled={true}/></div>
+        </div>          
+      {/if}
+    </div>
   </left>
   <right>
     <ImageImporter/>
@@ -18,6 +67,9 @@
     @apply flex justify-between h-full w-full overflow-hidden;
   }
   left {
+    display:flex;
+    flex-direction: column;
+    justify-content:start;
     @apply bg-gray-600 w-full h-full p-6 flex-col overflow-auto;
   }
   right {
@@ -38,4 +90,78 @@
   ul {
     @apply flex flex-col gap-2 w-full justify-center items-center;
   }
+  .inputGroup {
+    display: flex;
+    flex-direction: row;
+    height: auto;
+    gap: 20px;
+    width: 100%;
+    justify-content: center;
+  }
+  card {
+    width: auto;
+    padding-right: 10px;
+    padding-left: 10px;
+    height: 1.8em;
+    border-radius: 10px;
+    color: white;
+    text-align: center;
+    @apply bg-green-400 text-black dark:text-white;
+  }
+  .text{
+    text-align: center;
+    margin-top:5px;
+    margin-bottom:10px;
+  }
+  .imageLetter{
+    width: 50%;
+    text-align: center;
+    font-size: 20px;
+    margin-top:10px;
+  }
+  .cell {
+    width: 50%;
+  }
+  section {
+    background-color: #2c2c2f;
+    height: auto;
+    width: 80%;
+    min-height: 3.25em;
+    margin: auto;
+    border-radius: 10px;
+    justify-content: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    padding: 10px;
+  }
+  .artImageObjects{
+    max-height:210px;
+    overflow-y:auto;
+    scrollbar-width: 10px;
+  }
+
+  /* width */
+  .artImageObjects::-webkit-scrollbar {
+    @apply relative transition-all w-1;
+  }
+
+  /* Track */
+  .artImageObjects::-webkit-scrollbar-track {
+    @apply bg-transparent;
+  }
+
+  /* Handle */
+  .artImageObjects::-webkit-scrollbar-thumb {
+    @apply bg-gray-500 rounded-full;
+  }
+
+  /* Handle on hover */
+  .artImageObjects::-webkit-scrollbar-thumb:hover {
+    @apply bg-gray-700;
+  }
+    
+  
+    
 </style>

--- a/frontend/src/renderer/components/Process/Tabs/SelectProcessingType.svelte
+++ b/frontend/src/renderer/components/Process/Tabs/SelectProcessingType.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <main>
-  <div class="content">
+  <div id="selectProcessingTypesContent">
     <div class="btnCol">
       <button on:click={() => handleClick("Single")} class="homeBtn">
         <div class="btnTitle">
@@ -41,7 +41,7 @@
     @apply w-full h-[97%] bg-gray-800 mt-[3%] relative flex justify-center items-center;
   }
 
-  .content {
+  #selectProcessingTypesContent {
     @apply h-[50vh] flex flex-col items-center justify-between mb-[15vh];
   }
 

--- a/frontend/src/renderer/pages/Home.svelte
+++ b/frontend/src/renderer/pages/Home.svelte
@@ -38,7 +38,7 @@
       </div>
     </div>
   {/if}
-  <div class="content">
+  <div id="homeContent">
     <div id="welcome">
       <h1 in:fade={{ duration: 1000, delay: 1000 }} class="dark:text-gray-400">
         Welcome to
@@ -88,7 +88,7 @@
     @apply w-full h-[97%] bg-gray-800 mt-[3%] relative flex justify-center items-center;
   }
 
-  .content {
+  #homeContent {
     @apply h-[50vh] flex flex-col items-center justify-between mb-[15vh];
   }
 

--- a/frontend/src/renderer/pages/Reports.svelte
+++ b/frontend/src/renderer/pages/Reports.svelte
@@ -97,26 +97,6 @@
     mainfilePath = null;
   }
 
-  function detectZoom(event){ 
-   // Zoom in or out based on the scroll direction 
-    let direction = event.deltaY > 0 ? -1 : 1; 
-    zoomImage(direction); 
-  }
-
-  let currentZoom=1;let stepSize=0.05;
-  function zoomImage(direction) { 
-      let newZoom = currentZoom + direction * stepSize; 
-      // Limit the zoom level to the minimum and maximum values 
-      if (newZoom < 1 || newZoom > 3) { 
-          return; 
-      } 
-    
-      currentZoom = newZoom; 
-    
-      // Update the CSS transform of the image to scale it 
-      let image = document.querySelector("#cm-target-image"); 
-      image.style.transform = "scale(" + currentZoom + ')'; 
-  }
 </script>
 
 <main class="reports-main">

--- a/frontend/src/renderer/util/storesUtil.ts
+++ b/frontend/src/renderer/util/storesUtil.ts
@@ -1,0 +1,25 @@
+import {isEmpty} from "lodash";
+
+
+//Expects $processState?.artStacks[0].fields as input parameter; imageStack = get($processState, 'artStacks[0].fields');
+//go through $processState?.artStacks[0].fields and get an accurate count of the sorted image 
+export function countFields(imageStack) {
+    let sortedImagecount = 0;
+
+    //field is a string
+    for(var field in imageStack){
+        //imageA and imageB are 2d arrays
+        if(field=="imageA" || field=="imageB"){
+            for(let i=0; i < imageStack[field].length; i++){
+            // imageA and imageB can have an arbitrary length of empty arrays 
+            // so for each nested array check they are not empty
+                if (!isEmpty(imageStack[field][i])){
+                    sortedImagecount += imageStack[field][i].length;
+                }
+            }    
+        }else{ //other fields are 1d arrays
+            sortedImagecount += imageStack[field].length; //these lengths should always be 1
+        }
+    }
+    return sortedImagecount;
+}


### PR DESCRIPTION
Resolves #202 

Added display to UI on Import Images tab to show any files that were already sorted into processing roles (target, darkfield, etc.)

Also:
- removed unused code from Reports.svelte that were leftover from PR #200 
- added storesUtil.ts for function reuse
- super minor ui fix on BatchImageRoles.svelte
- added 'dragDisabled' parameter to Dropbox.svelte so the sorted images on ImageImporter cannot be dragged around (but still get to reuse the css)

Sorted page:
![image](https://github.com/BeyondRGB/Imaging-Art-beyond-RGB/assets/54516922/f503aea9-0c31-417c-b479-6fddca13c0ea)

Import images on backtrack:
![image](https://github.com/BeyondRGB/Imaging-Art-beyond-RGB/assets/54516922/c7c3d39e-b37a-4eca-a094-bcf9cf9d3ba4)

Additionally, updated function in ImageImporter and BatchProcessingRoles to get a more accurate count of images imported. So it combines both the unsorted image filepaths ($processState.imageFilePaths) and the sorted images ($processState.artStacks[0].fields) to count the total number of images. So if user decides they want to process more images in a batch, the BatchProccesingRoles tab will update to have boxes for all the images

Import Images with more unsorted art images:
![image](https://github.com/BeyondRGB/Imaging-Art-beyond-RGB/assets/54516922/e394620d-a73a-4bd0-8c76-d7b8fc48450c)

Updated Specify Batch Image roles tab:
![image](https://github.com/BeyondRGB/Imaging-Art-beyond-RGB/assets/54516922/5dc83e6e-52a5-49c5-b0af-9337fd63bdf6)


