### PR TITLE
add scrolling to batch image assignment page

### DIFF
--- a/frontend/src/renderer/components/Process/Tabs/BatchProcessingRoles.svelte
+++ b/frontend/src/renderer/components/Process/Tabs/BatchProcessingRoles.svelte
@@ -239,6 +239,7 @@
         max-height: calc(100% - 300px);
         overflow-y:auto;
         scrollbar-width: 10px;
+        padding-left: 20px;
     }
     .leftStartBox {
         max-height: 100px;

--- a/frontend/src/renderer/components/Process/Tabs/BatchProcessingRoles.svelte
+++ b/frontend/src/renderer/components/Process/Tabs/BatchProcessingRoles.svelte
@@ -236,6 +236,7 @@
         max-height:300px;
     }
     .leftBoxes {
+        margin-top: 5px;
         max-height: calc(100% - 300px);
         overflow-y:auto;
         scrollbar-width: 10px;

--- a/frontend/src/renderer/components/Process/Tabs/BatchProcessingRoles.svelte
+++ b/frontend/src/renderer/components/Process/Tabs/BatchProcessingRoles.svelte
@@ -86,19 +86,26 @@
 <main>
     {#key rerenderToggle}
         <panel>
-            <h1>Specify Image Roles Batch</h1>
-            <p>Drag and drop each image into its appropriate role</p>
-            <div>
-                <Dropbox bind:items={$processState.imageFilePaths} type="image" singleItem={false}/>
+            <div class="leftHeader">
+                <h1>Specify Image Roles Batch</h1>
+                <p>Drag and drop each image into its appropriate role</p>
+                <div class="leftStartBox">
+                    <Dropbox bind:items={$processState.imageFilePaths} type="image" singleItem={false}/>
+                </div>
                 <div class="btnGroup">
                     <button class="autoSortButton" on:click={autoSort}>Auto-sort images</button>
                 </div>
+                
+            </div>
+            <div class="leftBoxes">
+
                 <div class="centerFlexBox">
                 <div id="imageStack">
                     <div class="inputGroup">
                         <div class="imageLetter">A</div>
                         <div class="imageLetter">B</div>
                     </div>
+                    <div class='objectDropBoxes'>
                     <div class="text">Object</div>
                     {#each Array(artImageCount) as _, index (index)}
                     <div class="inputGroup">
@@ -106,6 +113,7 @@
                         <div class="cell"><Dropbox type="image" bind:items={imageStack.imageB[index]} singleItem={true} showError={!!validationError}/></div>
                     </div>
                     {/each}
+                    </div>
                     <br>
                 </div>
                 
@@ -197,6 +205,7 @@
         gap: 20px;
         width: 100%;
         justify-content: center;
+        padding-top: 20px;
     }
     .cell {
         width: 50%;
@@ -222,5 +231,18 @@
     }
     .nextBtn {
         @apply m-4 bg-green-700 hover:bg-green-600 focus:ring-green-600 transition-all;
+    }
+    .leftHeader {
+        max-height:300px;
+    }
+    .leftBoxes {
+        max-height: calc(100% - 300px);
+        overflow-y:auto;
+        scrollbar-width: 10px;
+    }
+    .leftStartBox {
+        max-height: 100px;
+        overflow-y:auto;
+        scrollbar-width: 5px;
     }
 </style>


### PR DESCRIPTION
This adds css to add scrolling to the batch images assignment page. It prevents the top dropbox from being larger than 100px, and allows the art object drop boxes to fill out the rest of the space of the page. The top dropbox is scrollable, as is the art images section.

![image](https://github.com/BeyondRGB/Imaging-Art-beyond-RGB/assets/15960388/baf5bc57-8c48-4a9a-ba87-c8b1cc9dccc8)
 
![image](https://github.com/BeyondRGB/Imaging-Art-beyond-RGB/assets/15960388/e2b7151b-9570-4fac-95bc-9407369b3561)

![image](https://github.com/BeyondRGB/Imaging-Art-beyond-RGB/assets/15960388/a0fe5836-e24a-4454-9896-c4a2c3859460)

