### PR TITLE
Squirrel installer hanging bugfix

### DIFF
--- a/frontend/src/main/index.js
+++ b/frontend/src/main/index.js
@@ -27,7 +27,7 @@ else {
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require('electron-squirrel-startup')) { // eslint-disable-line global-require
-  app.quit();
+  setTimeout(app.quit, 1000);
 }
 
 process.on('loaded', (event, args) => {


### PR DESCRIPTION
Added 1 second delay before shutting down the application when started up during the squirrel install. This prevents quitting before the installer can complete what it needs to with the running program, and allows the installer to finish.