### PR TITLE
More Information to Image Viewer error message

### DIFF
--- a/backend/src/backend_process/ColorManagedImage.cpp
+++ b/backend/src/backend_process/ColorManagedImage.cpp
@@ -32,7 +32,7 @@ void ColorManagedImage::run() {
         std::string filename = prj_filename.substr(0, prj_filename.find_last_of("/\\") + 1) + local_file;
 
         if( ! btrgb::Image::is_tiff(filename) )
-            throw std::runtime_error("Image is not a tiff file");
+            throw std::runtime_error("Missing tiff image files. Ensure that all tiff files produced by BeyondRGB are in the same directory as the btrgb project file.");
 
         cv::Mat im;
         tiff_reader->open(filename);

--- a/frontend/src/renderer/components/ServerError.svelte
+++ b/frontend/src/renderer/components/ServerError.svelte
@@ -21,8 +21,13 @@
    * reset fields in the processState
    */
   function returnToSetup() {
-    $processState.currentTab = 4;
-    $processState.completedTabs[$processState.currentTab] = false;
+    for (let i = 0; i < $processState.completedTabs.length - 1; i++) {
+      if ($processState.completedTabs[i+1] === false || i === $processState.completedTabs.length - 2) {
+        $processState.currentTab = i;
+        $processState.completedTabs[i] = false;
+        break;
+      }
+    }
     $processState.whitePatchFilled = false;
     $processState.returnedFromProcessing = true;
     if ($processState.artStacks[0].verificationTarget === null) {


### PR DESCRIPTION
Added more information to the error message when unable to read a tiff file while opening a btrgb project file.

Additionally fixed server error modal logic to correctly go back to the most recent tab instead of defaulting to tab 4. This fixes a bug where server errors while viewing a file incorrectly set process state when no processing was being done.