### PR TITLE
Base path points to the correct place now (`backend` dir)

### DIFF
--- a/backend/include/reference_data/ref_data_defines.hpp
+++ b/backend/include/reference_data/ref_data_defines.hpp
@@ -1,6 +1,8 @@
 #ifndef REF_DATA_DEFINE
 #define REF_DATA_DEFINE
 
+#include "server/globals_singleton.hpp"
+
 #define MAX_WAVE_LEN 730 // max wave length value
 #define MIN_WAVE_LEN 380 // min wave length value
 #define SAMPLING_INCREMENT 10 // wave length increments
@@ -13,8 +15,8 @@
 #define STANDARD_OBSERVER_SIZE REFLECTANCE_SIZE
 
 
-#define BASE_PATH "./" // relative to executable
-#define REF_DATA_PATH BASE_PATH "/res/ref_data/"
+#define BASE_PATH GlobalsSingleton::get_instance()->app_root()+"/"+ // relative to executable
+#define REF_DATA_PATH BASE_PATH "res/ref_data/"
 #define ILLUMINANTS_FILE_PATH REF_DATA_PATH "Illuminants.csv"
 #define STANDARD_OBSERVER_1931_PATH REF_DATA_PATH "Standard_Observer_1931.csv"
 #define STANDARD_OBSERVER_1964_PATH REF_DATA_PATH "Standard_Observer_1964.csv"

--- a/backend/include/server/globals_singleton.hpp
+++ b/backend/include/server/globals_singleton.hpp
@@ -2,6 +2,9 @@
 #define GLOBALS_SINGLTON_H
 
 #include <string>
+#include <filesystem>
+
+namespace fs = std::filesystem;
 
 class GlobalsSingleton {
 public:
@@ -21,7 +24,7 @@ private:
 	GlobalsSingleton() {}
 	static GlobalsSingleton* instance;
 	bool is_test_m = false;
-	std::string app_root_m = "./";
+	std::string app_root_m = fs::canonical("./..");
 	int port = 9002;
 
 };


### PR DESCRIPTION
When looking for reference data, the backend assumes it's running in the `backend` directory, which is incorrect. Instead, it's running in one of its subdirectories (I'd like a check on this on all OS's if time permits). So I just push the base path up one directory to fix that.