### PR TITLE
Force `getPort()` to only look on IPv4

### DIFF
--- a/backend/src/server/request_server.cpp
+++ b/backend/src/server/request_server.cpp
@@ -22,7 +22,7 @@ void RequestServer::init_server() {
                  ::_1, 
                  ::_2));
 
-        // Listen on port 9002
+        // Listen on port given by frontend
         server_m.listen(GlobalsSingleton::get_instance()->get_port());
     }
     catch (websocketpp::exception const& e) {

--- a/frontend/src/main/index.js
+++ b/frontend/src/main/index.js
@@ -99,7 +99,7 @@ ipcMain.handle('ipc-Dialog', async (event, arg) => {
 const createBackendContext = () => {
   // once port is received, it returns from .then() and continues forth
   // has to be done the line after, otherwise returns promise while awaiting
-  getPort({ host: '127.0.0.1' })
+  getPort({ host: '127.0.0.1', random: true})
     .then(port => {
       // kill backend if already running 
       if (loader)


### PR DESCRIPTION
Fixes the issue where sometimes `getPort` would return a port that is in use.