### PR TITLE
Fix getConversionMatrix in Image.cpp

### DIFF
--- a/backend/src/image_util/Image.cpp
+++ b/backend/src/image_util/Image.cpp
@@ -180,10 +180,9 @@ void Image::setColorProfile(ColorSpace color_profile) {
 ColorSpace Image::getColorProfile() const { return this->_color_profile; }
 
 void Image::setConversionMatrix(std::string key, cv::Mat m) {
-
-    if (this->_conversions.contains(key))
-        throw std::runtime_error(
-            "[Image::setConversionMatrix] Conversion matrix already exists.");
+    if (this->_conversions.contains(key)) {
+        throw std::runtime_error("[Image::setConversionMatrix] Conversion matrix already exists.");
+    }
 
     /* Only store as 32 bit floating point. */
     if (m.type() == CV_64FC1)
@@ -198,7 +197,7 @@ void Image::setConversionMatrix(std::string key, cv::Mat m) {
 }
 
 cv::Mat Image::getConversionMatrix(std::string key) {
-    if (this->_conversions.contains(key)) {
+    if (!this->_conversions.contains(key)) {
         throw std::runtime_error(
                "[Image::getConversionMatrix] Conversion matrix does not exists.");
     }


### PR DESCRIPTION
This fixes a problem that led to ICC Max profiles not properly embedding within images. Turns out, the images had the spectral data, but the function returning the data was broken.	There was no `!` in an if statement with in `getConversionMatrix` which causes it to throw an error when it does have a matrix, the **opposite** of what we want.